### PR TITLE
Clone `OAUTH2_URLS` hash before passing it to `OAuth2::Client#new`

### DIFF
--- a/lib/ruby-box/session.rb
+++ b/lib/ruby-box/session.rb
@@ -11,7 +11,7 @@ module RubyBox
     
     def initialize(opts={})
       if opts[:client_id]
-        @oauth2_client = OAuth2::Client.new(opts[:client_id], opts[:client_secret], OAUTH2_URLS)
+        @oauth2_client = OAuth2::Client.new(opts[:client_id], opts[:client_secret], OAUTH2_URLS.dup)
         @access_token = OAuth2::AccessToken.new(@oauth2_client, opts[:access_token]) if opts[:access_token]
       else # Support legacy API for historical reasons.
         @api_key = opts[:api_key]


### PR DESCRIPTION
The `OAuth2::Client` initializer mutates the hash of options passed to it, removing multiple keys from the hash before returning. This means that subsequent invocations will receive an incomplete hash of options.

By cloning the hash before instantiating the OAuth client, we allow the client to mutate the hash to its heart's content without interfering with the behavior of this library.

This is more of a problem with the `oauth2` gem than it is with `ruby-box`, as I think it is perfectly reasonable to expect libraries not to mutate arguments passed to their methods from outside of the library. As such, I've patched the issue in `oauth2` as well, but until [that pull request](https://github.com/intridea/oauth2/pull/131) is merged, this will fix the problem from the `ruby-box` end.
