### PR TITLE
Regenerate gemspec with oauth2 dependency (among other things)

### DIFF
--- a/ruby-box.gemspec
+++ b/ruby-box.gemspec
@@ -8,32 +8,60 @@ Gem::Specification.new do |s|
   s.version = "1.0.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Benjamin Coe", "Jesse Miller", "Larry Kang"]
-  s.date = "2013-03-02"
+  s.authors = ["Jesse Miller"]
+  s.date = "2013-03-25"
   s.description = "ruby gem for box.com 2.0 api"
-  s.email = "ben@attachments.me"
+  s.email = "millerjesse@gmail.com"
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.markdown"
   ]
-  s.files = `git ls-files`.gsub('"spec/fixtures/\351\201\240\345\277\227\346\225\231\346\216\210.jpg"', '').split($\)
-  s.homepage = "http://github.com/attachmentsme/ruby-box"
+  s.files = [
+    ".document",
+    "Gemfile",
+    "Gemfile.lock",
+    "LICENSE.txt",
+    "README.markdown",
+    "Rakefile",
+    "VERSION",
+    "lib/ruby-box.rb",
+    "lib/ruby-box/client.rb",
+    "lib/ruby-box/comment.rb",
+    "lib/ruby-box/discussion.rb",
+    "lib/ruby-box/exceptions.rb",
+    "lib/ruby-box/file.rb",
+    "lib/ruby-box/folder.rb",
+    "lib/ruby-box/item.rb",
+    "lib/ruby-box/session.rb",
+    "lib/ruby-box/user.rb",
+    "ruby-box.gemspec",
+    "spec/client_spec.rb",
+    "spec/file_spec.rb",
+    "spec/fixtures/遠志教授.jpg",
+    "spec/folder_spec.rb",
+    "spec/helper/account.example",
+    "spec/helper/account.rb",
+    "spec/integration_spec.rb"
+  ]
+  s.homepage = "http://github.com/jessemiller/ruby-box"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.24"
+  s.rubygems_version = "2.0.0"
   s.summary = "ruby gem for box.com 2.0 api"
 
   if s.respond_to? :specification_version then
-    s.specification_version = 3
+    s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<multipart-post>, ["~> 1.1.5"])
+      s.add_runtime_dependency(%q<oauth2>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_development_dependency(%q<webmock>, [">= 0"])
     else
       s.add_dependency(%q<multipart-post>, ["~> 1.1.5"])
+      s.add_dependency(%q<oauth2>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<bundler>, [">= 0"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.4"])
@@ -41,6 +69,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<multipart-post>, ["~> 1.1.5"])
+    s.add_dependency(%q<oauth2>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<bundler>, [">= 0"])
     s.add_dependency(%q<jeweler>, ["~> 1.6.4"])


### PR DESCRIPTION
In a Rails project with no pre-existing dependency on the `oauth2` gem, I get errors on startup after adding `ruby-box` to the `Gemfile`. This is ultimately due to the fact that `ruby-box` does not declare its dependency on `oauth2` in the gemspec.

Regenerating the gemspec with `bundle exec rake gemspec` cleared up this issue.
