### PR TITLE
Relieve `multipart-post` version constraint for Ruby 2.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "multipart-post", "~> 1.1.5"
+gem "multipart-post"
 gem "oauth2"
 
 group :development do

--- a/ruby-box.gemspec
+++ b/ruby-box.gemspec
@@ -53,14 +53,14 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<multipart-post>, ["~> 1.1.5"])
+      s.add_runtime_dependency(%q<multipart-post>, [">= 0"])
       s.add_runtime_dependency(%q<oauth2>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_development_dependency(%q<webmock>, [">= 0"])
     else
-      s.add_dependency(%q<multipart-post>, ["~> 1.1.5"])
+      s.add_dependency(%q<multipart-post>, [">= 0"])
       s.add_dependency(%q<oauth2>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<bundler>, [">= 0"])
@@ -68,7 +68,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<webmock>, [">= 0"])
     end
   else
-    s.add_dependency(%q<multipart-post>, ["~> 1.1.5"])
+    s.add_dependency(%q<multipart-post>, [">= 0"])
     s.add_dependency(%q<oauth2>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<bundler>, [">= 0"])


### PR DESCRIPTION
`multipart-post` versions prior to 1.2.0 are not compatible with Ruby 2.0; sending a request results in I/O errors (see https://github.com/nicksieger/multipart-post/pull/25).

I'm not sure if there was a specific reason why the version was previously pinned at 1.1.5. If removing that constraint is a problem, let me know, but the gem seems to be working fine on Ruby 2.0 now that it is gone.
