### PR TITLE
check if a folder already exists before trying to create one.

### DIFF
--- a/lib/ruby-box/client.rb
+++ b/lib/ruby-box/client.rb
@@ -55,9 +55,7 @@ module RubyBox
       folder = root_folder
       folder_names = split_path(path)
       folder_names.each do |folder_name|
-        new_folder = folder.folders(folder_name).first
-        # folder = new_folder ? new_folder : folder.create_subfolder(folder_name)
-        
+        new_folder = folder.folders(folder_name).first        
         if !new_folder
           begin
             new_folder = folder.create_subfolder(folder_name)

--- a/lib/ruby-box/client.rb
+++ b/lib/ruby-box/client.rb
@@ -56,12 +56,16 @@ module RubyBox
       folder_names = split_path(path)
       folder_names.each do |folder_name|
         new_folder = folder.folders(folder_name).first
-        begin
-          new_folder = folder.create_subfolder(folder_name)
-        rescue RubyBox::ItemNameInUse => e
-          new_folder = folder.folders(folder_name).first
+        # folder = new_folder ? new_folder : folder.create_subfolder(folder_name)
+        
+        if !new_folder
+          begin
+            new_folder = folder.create_subfolder(folder_name)
+          rescue RubyBox::ItemNameInUse => e
+            new_folder = folder.folders(folder_name).first
+          end
         end
-        folder = new_folder ? new_folder : folder.folders(folder_name).first
+        folder = new_folder
       end
       folder
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -25,4 +25,28 @@ describe RubyBox::Client do
       client.split_path('foo/bar/').should == ['foo', 'bar']
     end
   end
+  
+  describe '#create_folder' do
+    it 'doesnt call folder.create_folder if the folder exists' do
+      client = RubyBox::Client.new(@session)
+      mock_root_folder = mock( Object )
+      test_folder = mock( Object )
+      mock_root_folder.should_receive(:folders).and_return([test_folder])
+      mock_root_folder.should_not_receive(:create_subfolder)
+      client.should_receive(:root_folder).and_return(mock_root_folder)
+      result = client.create_folder( '/test0')
+      result.should == test_folder
+    end
+    
+    it 'calls folder.create_folder if the folder does not exist' do
+      client = RubyBox::Client.new(@session)
+      mock_root_folder = mock( Object )
+      test_folder = mock( Object )
+      mock_root_folder.should_receive(:folders).and_return([])
+      mock_root_folder.should_receive(:create_subfolder).and_return(test_folder)
+      client.should_receive(:root_folder).and_return(mock_root_folder)
+      result = client.create_folder( '/test0')
+      result.should == test_folder
+    end
+  end
 end


### PR DESCRIPTION
Client#create was trying to create a folder even though one might have already existed.  The    "create_subfolder" doesnt always give the ItemNameInUse exception, so check existance before calling create.

solves issue #17 
