### PR TITLE
Add support for RubyBox::Event#source?

### DIFF
--- a/lib/ruby-box/event.rb
+++ b/lib/ruby-box/event.rb
@@ -1,5 +1,9 @@
 module RubyBox
   class Event < Item
 
+    def source?
+      !@raw_item['source'].nil?
+    end
+
   end
 end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -53,5 +53,18 @@ describe RubyBox::EventResponse do
 
   end
 
+  describe RubyBox::Event do
+    before do
+      @eresp = @client.event_response
+      @rbevents = @eresp.events
+    end
+
+    it '#source?' do
+      @rbevents[0].source?.should be_true
+      @rbevents[2].source?.should be_false
+    end
+
+  end
+
 end
 


### PR DESCRIPTION
This is probably not worthy of a 1.1.1 release but next time you release it would be awesome if you could add this in. Sometimes an event won't have a source associated with it and therefore gives you a "stack level too deep" error when trying to access it. I added this so you can `ev.source if ev.source?` when accessing it. Maybe there is an easier way to do this but it wasn't evident to me in the item.rb code.

Cheers,

Dan
