### PR TITLE
Add WebLink item type

### DIFF
--- a/lib/ruby-box.rb
+++ b/lib/ruby-box.rb
@@ -10,6 +10,7 @@ require 'ruby-box/discussion'
 require 'ruby-box/exceptions'
 require 'ruby-box/event_response'
 require 'ruby-box/event'
+require 'ruby-box/web_link'
 
 module RubyBox
   API_URL = 'https://api.box.com/2.0'

--- a/lib/ruby-box/item.rb
+++ b/lib/ruby-box/item.rb
@@ -84,6 +84,8 @@ module RubyBox
         return RubyBox::User.new(session, entry)
       when 'discussion'
         return RubyBox::Discussion.new(session, entry)
+      when 'web_link'
+        return RubyBox::WebLink.new(session, entry)
       end
       entry
     end

--- a/lib/ruby-box/web_link.rb
+++ b/lib/ruby-box/web_link.rb
@@ -1,0 +1,11 @@
+module RubyBox
+  class WebLink < Item
+
+    private
+
+    def has_mini_format?
+      false
+    end
+
+  end
+end


### PR DESCRIPTION
Adds the WebLink type. It comes through in events and this is needed for proper behavior.
