### PR TITLE
Added :now to Event API

### DIFF
--- a/lib/ruby-box/client.rb
+++ b/lib/ruby-box/client.rb
@@ -113,7 +113,7 @@ module RubyBox
     end
 
     def fmt_events_args(stream_position, stream_type, limit)
-      unless stream_position == 'now'
+      unless stream_position.to_s == 'now'
         stream_position = stream_position.kind_of?(Numeric) ? stream_position : 0
       end
       stream_type = [:all, :changes, :sync].include?(stream_type) ? stream_type : :all

--- a/lib/ruby-box/client.rb
+++ b/lib/ruby-box/client.rb
@@ -108,7 +108,9 @@ module RubyBox
     end
 
     def fmt_events_args(stream_position, stream_type, limit)
-      stream_position = stream_position.kind_of?(Numeric) ? stream_position : 0
+      unless stream_position == 'now'
+        stream_position = stream_position.kind_of?(Numeric) ? stream_position : 0
+      end
       stream_type = [:all, :changes, :sync].include?(stream_type) ? stream_type : :all
       limit = limit.kind_of?(Fixnum) ? limit : 100
       "stream_position=#{stream_position}&stream_type=#{stream_type}&limit=#{limit}"

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -29,6 +29,11 @@ describe RubyBox::EventResponse do
     event.missing_key
   end
 
+  it '#fmt_events_args should return a properly formatted URL' do
+    @client.send(:fmt_events_args, 0, :all, 100).should eql("stream_position=0&stream_type=all&limit=100")
+    @client.send(:fmt_events_args, 'now', :changes, 55).should eql("stream_position=now&stream_type=changes&limit=55")
+  end
+
   describe '#event_response' do
     before do
       @response = @client.event_response


### PR DESCRIPTION
I merged in:

https://github.com/attachmentsme/ruby-box/pull/28

the only change I made was making it so now could either be a string or a symbol.
