### PR TITLE
Bug fix for Item.factory when the @raw_item does not have a 'type' key.

### DIFF
--- a/lib/ruby-box/item.rb
+++ b/lib/ruby-box/item.rb
@@ -73,7 +73,7 @@ module RubyBox
     protected
 
     def self.factory(session, entry)
-      type = entry['type'].capitalize.to_sym
+      type = entry['type'] ? entry['type'].capitalize.to_sym : nil
       if RubyBox.constants.include? type
         RubyBox.const_get(type).new(session, entry)
       else


### PR DESCRIPTION
There are a couple event responses that have a #source without a 'type' key and it was blowing up here. This will make it behave correctly.
