### PR TITLE
added copy_to method for RubyBox::File

### DIFF
--- a/lib/ruby-box/file.rb
+++ b/lib/ruby-box/file.rb
@@ -7,6 +7,15 @@ module RubyBox
       resp = stream.read
     end
 
+    def copy_to( folder_id, name=nil )
+      url = "#{RubyBox::API_URL}/#{resource_name}/#{id}/copy"
+      uri = URI.parse(url)
+      request = Net::HTTP::Post.new( uri.request_uri )
+      request.body = JSON.dump({ "parent" => {"id" => folder_id},
+        "name" => name})
+      resp = @session.request(uri, request)
+    end
+
     def stream( opts={} )
       url = "#{RubyBox::API_URL}/#{resource_name}/#{id}/content"
       @session.do_stream( url, opts )


### PR DESCRIPTION
added copy_to method to RubyBox::File

RubyBox::File.copy_to( FolderID, name<optional> )

Could easily change this to accept the new remote file path as a parameter instead of the folderID and optional name. Then parse the new path into the new name and make an additional call to do the folderID lookup. This accomplished what i need though.
