### PR TITLE
Allow folders to be able to be moved

### DIFF
--- a/lib/ruby-box/file.rb
+++ b/lib/ruby-box/file.rb
@@ -7,17 +7,6 @@ module RubyBox
       resp = stream.read
     end
 
-    def move_to( folder_id, name=nil )
-      # Allow either a folder_id or a folder object
-      # to be passed in.
-      folder_id = folder_id.id if folder_id.instance_of?(RubyBox::Folder)
-
-      self.name = name if name
-      self.parent = {"id" => folder_id}
-
-      update
-    end
-
     def copy_to( folder_id, name=nil )
 
       # Allow either a folder_id or a folder object
@@ -90,10 +79,6 @@ module RubyBox
 
     def has_mini_format?
       true
-    end
-
-    def update_fields
-      ['name', 'description', 'parent']
     end
 
     def prepare_upload(data, fname)

--- a/lib/ruby-box/folder.rb
+++ b/lib/ruby-box/folder.rb
@@ -77,10 +77,6 @@ module RubyBox
       true
     end
 
-    def update_fields
-      ['name', 'description']
-    end
-
     def items_by_type(type, name, item_limit, offset, fields)
 
       # allow paramters to be set via

--- a/lib/ruby-box/item.rb
+++ b/lib/ruby-box/item.rb
@@ -20,6 +20,17 @@ module RubyBox
       keys.each {|key| @@has_many_paginated << key.to_s}
     end
 
+    def move_to( folder_id, name=nil )
+      # Allow either a folder_id or a folder object
+      # to be passed in.
+      folder_id = folder_id.id if folder_id.instance_of?(RubyBox::Folder)
+
+      self.name = name if name
+      self.parent = {"id" => folder_id}
+
+      update
+    end
+
     def update
       reload_meta unless etag
 
@@ -160,6 +171,11 @@ module RubyBox
     def serialize
       update_fields.inject({}) {|hash, field| hash[field] = @raw_item[field]; hash}
     end
+
+    def update_fields
+      ['name', 'description', 'parent']
+    end
+
 
   end
 end


### PR DESCRIPTION
From the docs, folders can be moved just like files. Moved the File#move_to method to Item#move_to so it is available for both files and folders. 
Also, folders can now update their parent, so the `update_fields` for both File and Folder are the same, so they have also been moved to the Item class. 
