### PR TITLE
Download url

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -125,19 +125,11 @@ file = client.upload_file('./LICENSE.txt', '/license_folder')
 f = open('./LOCAL.txt', 'w+')
 f.write( client.file('/license_folder/LICENSE.txt').download )
 f.close()
-<<<<<<< HEAD
-=======
-
-# do this if you can
-f = open('./LOCAL.txt', 'w+')
-f.write( client.file_by_id(@file_id).download ) # lookups by id are more efficient
-f.close()
 
 # You can also grab the raw url with
 client.file_by_id(@file_id).download_url
 # Note that this URL is not persistent. Clients will need to follow the url immediately in order to
 # actually download the file
->>>>>>> 1df9f2f... Allow the download url to be returned
 ```
 
 * Deleting a file.

--- a/README.markdown
+++ b/README.markdown
@@ -125,6 +125,19 @@ file = client.upload_file('./LICENSE.txt', '/license_folder')
 f = open('./LOCAL.txt', 'w+')
 f.write( client.file('/license_folder/LICENSE.txt').download )
 f.close()
+<<<<<<< HEAD
+=======
+
+# do this if you can
+f = open('./LOCAL.txt', 'w+')
+f.write( client.file_by_id(@file_id).download ) # lookups by id are more efficient
+f.close()
+
+# You can also grab the raw url with
+client.file_by_id(@file_id).download_url
+# Note that this URL is not persistent. Clients will need to follow the url immediately in order to
+# actually download the file
+>>>>>>> 1df9f2f... Allow the download url to be returned
 ```
 
 * Deleting a file.

--- a/lib/ruby-box/file.rb
+++ b/lib/ruby-box/file.rb
@@ -18,6 +18,10 @@ module RubyBox
       update
     end
 
+    def download_url
+      get(file_content_url)["message"]
+    end
+
     def copy_to( folder_id, name=nil )
 
       # Allow either a folder_id or a folder object
@@ -35,8 +39,7 @@ module RubyBox
     end
 
     def stream( opts={} )
-      url = "#{RubyBox::API_URL}/#{resource_name}/#{id}/content"
-      @session.do_stream( url, opts )
+      @session.do_stream( file_content_url, opts )
     end
 
     def upload_content( data )
@@ -83,6 +86,10 @@ module RubyBox
     end
 
     private
+    def file_content_url
+      "#{RubyBox::API_URL}/#{resource_name}/#{id}/content"
+    end
+    
 
     def resource_name
       'files'

--- a/lib/ruby-box/file.rb
+++ b/lib/ruby-box/file.rb
@@ -19,7 +19,7 @@ module RubyBox
     end
 
     def download_url
-      get(file_content_url)["message"]
+      @session.get(file_content_url)["message"]
     end
 
     def copy_to( folder_id, name=nil )

--- a/lib/ruby-box/file.rb
+++ b/lib/ruby-box/file.rb
@@ -19,7 +19,7 @@ module RubyBox
     end
 
     def download_url
-      @session.get(file_content_url)["message"]
+      @session.get( file_content_url )["location"]
     end
 
     def copy_to( folder_id, name=nil )
@@ -39,7 +39,7 @@ module RubyBox
     end
 
     def stream( opts={} )
-      @session.do_stream( file_content_url, opts )
+      open(download_url, opts)
     end
 
     def upload_content( data )

--- a/lib/ruby-box/session.rb
+++ b/lib/ruby-box/session.rb
@@ -115,7 +115,7 @@ module RubyBox
       case status / 100
       when 3
         # 302 Found. We should return the url
-        parsed_body["message"] = response["Location"] if status == 302                  
+        parsed_body["location"] = response["Location"] if status == 302                  
       when 4
         raise(RubyBox::ItemNameInUse.new(parsed_body, status, body), parsed_body["message"]) if parsed_body["code"] == "item_name_in_use"
         raise(RubyBox::AuthError.new(parsed_body, status, body), parsed_body["message"]) if parsed_body["code"] == "unauthorized" || status == 401


### PR DESCRIPTION
Adding a new method to the File class that will grab the short lived download url. 
Adjusting the old `File#download` method to use this instead. 

Motivation for this change: 
Assuming that a user is interacting with the gem through a browser. 

Most of the time we do not want to download the file, and then send it to the client since if the file is large we will have to download the full file before sending it and that could take quite some time which will slow down the requests. Instead, we can redirect to the download url and let the user download it directly. 
