### PR TITLE
The name comparison for item searching should be case insensitive

### DIFF
--- a/lib/ruby-box/folder.rb
+++ b/lib/ruby-box/folder.rb
@@ -86,7 +86,7 @@ module RubyBox
       end
 
       items(item_limit, offset, fields).select do |item|
-        item.kind_of? type and (name.nil? or item.name == name)
+        item.kind_of? type and (name.nil? or item.name.casecmp(name) == 0)
       end
 
     end


### PR DESCRIPTION
The box folder creation is case insensitive so that creating a folder `"a"` and then folder `"A"` will result in an exception `RubyBox::ItemNameInUse`
Thus, we should be able to find the folder `"a"` with a search of `"A"`
