### PR TITLE
Update folder shared link README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -153,7 +153,7 @@ discussion.comments.each {|comment| p comment.message}
 
 ```ruby
 folder = client.folder('image_folder').create_shared_link # lookups by id are more efficient
-p folder.shared_link['url'] # https://www.box.com/s/d6de3224958c1755412
+p folder.shared_link.url # https://www.box.com/s/d6de3224958c1755412
 ```
 
 Files


### PR DESCRIPTION
![1 ruby irontweet rb ruby 2014-03-21 13-57-43 2014-03-21 13-57-46](https://f.cloud.github.com/assets/1712162/2487919/a78e49a4-b13b-11e3-8deb-8105ee24b894.png)
cannot use hash syntax to access the shared link for url
works
p folder.shared_link.url # https://www.box.com/s/d6de3224958c1755412

looking forward to BOXDEV!

woah this github selfie chrome plugin... is crazy.
![selfie-4](http://i.imgur.com/ta4AylY.png)
