### PR TITLE
Re-uploading existing file was failing

### DIFF
--- a/lib/ruby-box/folder.rb
+++ b/lib/ruby-box/folder.rb
@@ -34,10 +34,12 @@ module RubyBox
         # This is a workaround around:
         begin
           # were were given context information about this conflict?
-          file = RubyBox::File.new(@session, {
-            'id' => e['context_info']['conflicts'][0]['id']
-          })
-        rescue
+          # conflicts an either be an array or a hash
+          if (context_info = e['context_info']) && (conflicts = context_info['conflicts']) && (conflict = [conflicts].flatten(1).first) && (id = conflict['id'])
+            file = RubyBox::File.new(@session, {
+              'id' => id
+            })
+          else
           # we were not given context information about this conflict.
           # attempt to lookup the file.
           file = files(filename, 1000).pop


### PR DESCRIPTION
The context_info contains a conflicts hash or a conflicts array depending on the number of conflicts. We should make sure we handle both cases correctly.
