### PR TITLE
token refresh fix

### DIFF
--- a/lib/ruby-box/session.rb
+++ b/lib/ruby-box/session.rb
@@ -64,14 +64,17 @@ module RubyBox
       #http.set_debug_output($stdout)
 
       if @access_token
+        request.delete('Authorization')
         request.add_field('Authorization', "Bearer #{@access_token.token}")
       else
+        request.delete('Authorization')
         request.add_field('Authorization', build_auth_header)
       end
 
-
-      request.add_field('As-User', "#{@as_user}") if @as_user
-
+      if @as_user
+        request.delete('As-User')
+        request.add_field('As-User', "#{@as_user}")
+      end
       response = http.request(request)
 
       if response.is_a? Net::HTTPNotFound


### PR DESCRIPTION
Problem description: While access_token is refreshing the method RubyBox::Session.request is called twice with the same request param. That cause twice call of
request.add_field('Authorization', "Bearer #{@access_token.token}")
That lead to wrong header like authorization: Bearer oldaccess_token, Bearer newaccess_token
and failed auth

This fix assures there is no extra header (and also the same for the header As-User)
