### PR TITLE
Feature/add fields param

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem "bundler"
   gem "jeweler", "~> 1.6.4"
   gem "webmock"
+  gem "pry"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.2.8)
+    coderay (1.1.0)
     crack (0.3.1)
     diff-lcs (1.1.3)
     faraday (0.8.4)
@@ -15,6 +16,7 @@ GEM
     json (1.7.7)
     jwt (0.1.5)
       multi_json (>= 1.0)
+    method_source (0.8.2)
     multi_json (1.6.0)
     multipart-post (1.1.5)
     oauth2 (0.8.0)
@@ -23,6 +25,10 @@ GEM
       jwt (~> 0.1.4)
       multi_json (~> 1.0)
       rack (~> 1.2)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.4.5)
     rake (0.9.2.2)
     rspec (2.10.0)
@@ -33,6 +39,7 @@ GEM
     rspec-expectations (2.10.0)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.10.1)
+    slop (3.6.0)
     webmock (1.8.7)
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
@@ -47,5 +54,6 @@ DEPENDENCIES
   json
   multipart-post
   oauth2
+  pry
   rspec
   webmock

--- a/README.markdown
+++ b/README.markdown
@@ -37,7 +37,7 @@ p '@token.refresh_token' # token that can be exchanged for a new access_token on
 session = RubyBox::Session.new({
   client_id: 'your-client-id',
   client_secret: 'your-client-secret',
-  access_token: 'original-access-token' 
+  access_token: 'original-access-token'
 })
 
 # you need to persist this somehow. the refresh token will change every time you use it
@@ -172,7 +172,7 @@ p file.created_at
 
 ```ruby
 file = client.upload_file('./LICENSE.txt', '/license_folder') # lookups by id are more efficient
-file = client.upload_file_by_folder_id('./LICENSE.txt', @folder_id) 
+file = client.upload_file_by_folder_id('./LICENSE.txt', @folder_id)
 ```
 
 * Downloading a file.
@@ -307,6 +307,12 @@ Current User Info
 me = client.me
 ```
 
+* Remember you can request some especific fields
+
+```ruby
+me = client.me(fields: 'role')
+```
+
 Current User's enterprise
 
 ```ruby
@@ -322,7 +328,10 @@ users = client.users
 * Remeber the API filters "name" and "login" by the start of the string.  ie: to get "sean+awesome@gmail.com" an approriate filter term would be "sean"
 
 ```ruby
-users = client.users("sean" , 10 , 1)
+users = client.users(filter_term: 'sean',
+                     limit: 10,
+                     offset: 1,
+                     fields: 'role')
 ```
 
 Contributors
@@ -334,7 +343,7 @@ Contributing to ruby-box
 ========================
 
 RubyBox does not yet support all of Box's API Version 2.0 functionality, be liberal with your contributions.
- 
+
 * Rename account.example to account.yml and fill in your Box credentials
 * Type bundle install
 * Type rake.. tests should pass

--- a/lib/ruby-box/client.rb
+++ b/lib/ruby-box/client.rb
@@ -118,20 +118,55 @@ module RubyBox
       EventResponse.new(@session, resp)
     end
 
-    def me
-      resp = @session.get( "#{RubyBox::API_URL}/users/me" )
+    # Current user information
+    #
+    # @params query_params [Hash] query_params to add to the request
+    # @option query_params [String] fields () fields to show in the request sparated by commas
+    # @return [RubyBox::User]
+    def me(query_params={})
+      url = url_with_query_params("#{RubyBox::API_URL}/users/me", query_params)
+      resp = @session.get(url)
       User.new(@session, resp)
     end
 
-    def users(filter_term = "", limit = 100, offset = 0)
-      url = "#{RubyBox::API_URL}/users?filter_term=#{URI::encode(filter_term)}&limit=#{limit}&offset=#{offset}"
-      resp = @session.get( url )
+    # Enterprise users collection
+    #
+    # @params query_params [Hash] query_params to add to the request
+    # @option query_params [String] filter_term ('') A string used to filter the results to only users starting with the filter_term in either the name or the login
+    # @option query_params [Integer] limit (100) The number of records to return. (max=1000)
+    # @option query_params [Integer] offset (0) The record at which to start
+    # @return [Array(RubyBox::User)]
+    def users(query_params={})
+      query_params = query_params_with_default(query_params,  { filter_term: '', limit: 100, offset: 0 })
+      url = url_with_query_params("#{RubyBox::API_URL}/users", query_params)
+      resp = @session.get(url)
       resp['entries'].map do |entry|
         RubyBox::Item.factory(@session, entry)
       end
     end
 
     private
+
+    # Joins given base url with the given params
+    #
+    # @params base_url [String] base url to join
+    # @params query_params [Hash] given query params to join with the base url
+    # @return [String]
+    def url_with_query_params(base_url, query_params={})
+      uri = URI.parse(base_url)
+      new_query_params = URI.decode_www_form(uri.query || '') + query_params.to_a
+      uri.query = URI.encode_www_form(new_query_params)
+      uri.to_s
+    end
+
+    # Joins params with given default options
+    #
+    # @params query_params [Hash] given query params
+    # @params default_options [Hash] default query params values if any of them are not given
+    # @return [Hash]
+    def query_params_with_default(query_params={}, default_options={})
+      default_options.merge(query_params)
+    end
 
     def upload_file_to_folder(local_path, folder, overwrite)
       file_name = local_path.split('/').pop

--- a/spec/me_spec.rb
+++ b/spec/me_spec.rb
@@ -17,4 +17,20 @@ describe '/users/me' do
     me.instance_of?(RubyBox::User).should be_true
   end
 
+  context 'with fields query param given' do
+    let(:me_with_role_json) do
+      hash = JSON.parse(@me_json)
+      hash['role'] = 'coadmin'
+      hash.to_json
+    end
+
+    before do
+      stub_request(:get, /#{RubyBox::API_URL}\/users\/me\?fields=role/).to_return(body: me_with_role_json,
+                                                                                  :status => 200)
+    end
+    subject { @client.me(fields: 'role') }
+
+    it { should be_a RubyBox::User }
+    its(:role) { should eq 'coadmin' }
+  end
 end

--- a/spec/users_spec.rb
+++ b/spec/users_spec.rb
@@ -4,6 +4,9 @@ require 'ruby-box'
 require 'webmock/rspec'
 
 describe '/users' do
+  subject { @client.users }
+  let(:user) { subject.first }
+
   before do
     @session = RubyBox::Session.new
     @client  = RubyBox::Client.new(@session)
@@ -13,12 +16,57 @@ describe '/users' do
   end
 
   it 'should return a list of all users in the enterprise' do
-    users  = @client.users
-    users.instance_of?(Array).should be_true
+    subject.should be_a Array
   end
 
   it 'should return a list of all users in the enterprise as a user object' do
-    users  = @client.users
-    users.first.instance_of?(RubyBox::User).should be_true
+    user.should be_a RubyBox::User
+  end
+
+  it 'calls users endpoint with default query params' do
+    subject
+    assert_requested :get, "#{RubyBox::API_URL}/users?filter_term=&limit=100&offset=0"
+  end
+
+  context 'with filter_term param given' do
+    subject { @client.users(filter_term: 'foo') }
+
+    it 'overwrites the default value' do
+      subject
+      assert_requested :get, "#{RubyBox::API_URL}/users?filter_term=foo&limit=100&offset=0"
+    end
+  end
+
+  context 'with limit and offset params given' do
+    subject { @client.users(limit: 500, offset: 100) }
+
+    it 'overwrites the default values' do
+      subject
+      assert_requested :get, "#{RubyBox::API_URL}/users?filter_term=&limit=500&offset=100"
+    end
+  end
+
+  context 'with fields query param given' do
+    let(:users_with_role_json) do
+      hash = JSON.parse(@users_json)
+      array = hash['entries']
+      array.collect! do |user_hash|
+        user_hash['role'] = 'coadmin'
+        user_hash
+      end
+      hash['entries'] = array
+      hash.to_json
+    end
+    let(:user) { subject.first }
+
+    before do
+      stub_request(:get, /#{RubyBox::API_URL}\/users\?fields=role/).to_return(body: users_with_role_json,
+                                                                              :status => 200)
+    end
+    subject { @client.users(fields: 'role') }
+
+    it { should be_a Array }
+    it { user.should be_a RubyBox::User }
+    it { user.role.should eql 'coadmin' }
   end
 end


### PR DESCRIPTION
Added the ability to use additional query params to `users` and `me` in order to allow:

``` Ruby
client.users(fields: 'role', limit: 1000)
client.me(fields: 'role')
```

Changed also the Reame sections and added specs
