### PR TITLE
Remove explicit setting of sslv3 ssl version

### DIFF
--- a/lib/ruby-box/session.rb
+++ b/lib/ruby-box/session.rb
@@ -60,7 +60,6 @@ module RubyBox
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      http.ssl_version = :SSLv3
       #http.set_debug_output($stdout)
 
       if @access_token


### PR DESCRIPTION
It looks like Box removed SSLv3 support because of Poodle. This no longer forces the gem to use SSLv3, net/http and the like will automatically go to TLS if you let it.
