### PR TITLE
Lazy load folder and file meta

### DIFF
--- a/lib/ruby-box/client.rb
+++ b/lib/ruby-box/client.rb
@@ -16,8 +16,7 @@ module RubyBox
     end
 
     def folder_by_id(id)
-      folder = Folder.new(@session, {'id' => id})
-      folder.reload_meta
+      Folder.new(@session, {'id' => id})
     end
 
     def folder(path='/')
@@ -27,8 +26,7 @@ module RubyBox
     end
 
     def file_by_id(id)
-      file = File.new(@session, {'id' => id})
-      file.reload_meta
+      File.new(@session, {'id' => id})
     end
 
     def file(path)


### PR DESCRIPTION
This works for me but YMMV so please advise and let me know how can I improve this.

Say you want to list items in root folder:

```
client.root_folder.items
```

This launches two calls to Box API:
- call to fetch root folder meta,
- call to fetch root folder items.

For this particular case all I need is just items and with lazy loading I can skip one API call for root folder and just fetch root folder items directly.
