### PR TITLE
Add possibility to specify which fields should be loaded

### DIFF
--- a/lib/ruby-box/client.rb
+++ b/lib/ruby-box/client.rb
@@ -15,9 +15,9 @@ module RubyBox
       folder_by_id('0')
     end
 
-    def folder_by_id(id)
+    def folder_by_id(id, fields=nil)
       folder = Folder.new(@session, {'id' => id})
-      folder.reload_meta
+      folder.reload_meta(fields)
     end
 
     def folder(path='/')
@@ -26,9 +26,9 @@ module RubyBox
       folder_from_split_path( split_path(path) )
     end
 
-    def file_by_id(id)
+    def file_by_id(id, fields=nil)
       file = File.new(@session, {'id' => id})
-      file.reload_meta
+      file.reload_meta(fields)
     end
 
     def file(path)

--- a/lib/ruby-box/item.rb
+++ b/lib/ruby-box/item.rb
@@ -63,8 +63,9 @@ module RubyBox
       resp = @session.delete( url )
     end
 
-    def reload_meta
+    def reload_meta(fields=nil)
       url = "#{RubyBox::API_URL}/#{resource_name}/#{@raw_item['id']}"
+      url = "#{url}?fields=#{fields.map(&:to_s).join(',')}" if fields
       @raw_item = @session.get( url )
       self
     end
@@ -175,7 +176,5 @@ module RubyBox
     def update_fields
       ['name', 'description', 'parent']
     end
-
-
   end
 end


### PR DESCRIPTION
Before this commit it was impossible to load particular items with custom fields. With this commit you can do it directly when loading item by ID:

```
file = client.file_by_id('12345', [:name, :version_number])
file.version_number
```

Or manually by calling `#update_metadata`:

```
file = client.file('document.pdf')
file.reload_meta([:version_number])
file.version_number
```

You can find more information here: https://developers.box.com/docs/#fields
