### PR TITLE
Add support for configuring timeouts in RubyBox::Session

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,7 +37,7 @@ p '@token.refresh_token' # token that can be exchanged for a new access_token on
 session = RubyBox::Session.new({
   client_id: 'your-client-id',
   client_secret: 'your-client-secret',
-  access_token: 'original-access-token' 
+  access_token: 'original-access-token'
 })
 
 # you need to persist this somehow. the refresh token will change every time you use it
@@ -58,6 +58,28 @@ session = RubyBox::Session.new({
 
 client = RubyBox::Client.new(session)
 ```
+
+Configuration
+=============
+
+The `RubyBox::Session` can take network timeout options, if desired:
+
+``` ruby
+session = RubyBox::Session.new({
+  client_id: 'your-client-id',
+  client_secret: 'your-client-secret',
+  access_token: 'access-token',
+  read_timeout: 60,
+  open_timeout: 30
+})
+
+```
+
+`read_timeout` and `open_timeout` are passed along to `Net::HTTP` if present. From the ruby documentations:
+
+> read_timeout: Number of seconds to wait for one block to be read (via one read(2) call). Any number may be used, including Floats for fractional seconds.
+
+> open_timeout: Number of seconds to wait for the connection to open. Any number may be used, including Floats for fractional seconds.
 
 Usage
 =====
@@ -172,7 +194,7 @@ p file.created_at
 
 ```ruby
 file = client.upload_file('./LICENSE.txt', '/license_folder') # lookups by id are more efficient
-file = client.upload_file_by_folder_id('./LICENSE.txt', @folder_id) 
+file = client.upload_file_by_folder_id('./LICENSE.txt', @folder_id)
 ```
 
 * Downloading a file.
@@ -334,7 +356,7 @@ Contributing to ruby-box
 ========================
 
 RubyBox does not yet support all of Box's API Version 2.0 functionality, be liberal with your contributions.
- 
+
 * Rename account.example to account.yml and fill in your Box credentials
 * Type bundle install
 * Type rake.. tests should pass

--- a/lib/ruby-box/session.rb
+++ b/lib/ruby-box/session.rb
@@ -22,6 +22,8 @@ module RubyBox
         @api_key = opts[:api_key]
         @auth_token = opts[:auth_token]
       end
+      @read_timeout = opts[:read_timeout]
+      @open_timeout = opts[:open_timeout]
     end
 
     def authorize_url(redirect_uri, state=nil)
@@ -57,9 +59,10 @@ module RubyBox
     end
 
     def request(uri, request, raw=false, retries=0)
-
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
+      http.read_timeout = @read_timeout if @read_timeout
+      http.open_timeout = @open_timeout if @open_timeout
       #http.set_debug_output($stdout)
 
       if @access_token

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'ruby-box'
+require "webmock/rspec"
 
 describe RubyBox::Session do
   before do
@@ -29,6 +30,46 @@ describe RubyBox::Session do
     it "should accept redirect_uri and state" do
       @auth_code.should_receive(:authorize_url).with({ redirect_uri: redirect_uri, state: state})
       @session.authorize_url(redirect_uri, state)
+    end
+  end
+
+  describe "timeout options" do
+    let(:read_timeout) { 42 }
+    let(:open_timeout) { 42.0 }
+    let(:uri) { URI("https://www.google.com/") }
+    let(:request) { Net::HTTP::Get.new(uri.request_uri) }
+
+    before do
+      stub_request(:get, uri.to_s).to_return(body: "Hello, World!", :status => 200)
+    end
+
+    context "when timeout options are set" do
+      let(:session) {
+        RubyBox::Session.new(client_id: "client id",
+                             client_secret: "client secret",
+                             read_timeout: read_timeout,
+                             open_timeout: open_timeout)
+      }
+
+      it "passes them along to Net::HTTP" do
+        Net::HTTP.any_instance.should_receive(:read_timeout=).with(read_timeout)
+        Net::HTTP.any_instance.should_receive(:open_timeout=).with(open_timeout)
+        session.request(uri, request)
+      end
+    end
+
+    context "when the timeout options are not set" do
+      let(:session) {
+        RubyBox::Session.new(client_id: "client id",
+                             client_secret: "client secret"
+                             )
+      }
+
+      it "does not passes them along to Net::HTTP, in order to use that library's defaults" do
+        Net::HTTP.any_instance.should_not_receive(:read_timeout=).with(read_timeout)
+        Net::HTTP.any_instance.should_not_receive(:open_timeout=).with(open_timeout)
+        session.request(uri, request)
+      end
     end
   end
 end

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -56,6 +56,13 @@ describe RubyBox::Session do
         Net::HTTP.any_instance.should_receive(:open_timeout=).with(open_timeout)
         session.request(uri, request)
       end
+
+      it "passes options along to OAuth2 (so that it can pass along to Faraday)" do
+        OAuth2::Client.should_receive(:new) do |_, _, opts|
+          opts[:connection_opts].should == { request: { timeout: read_timeout, open_timeout: open_timeout } }
+        end
+        session.request(uri, request)
+      end
     end
 
     context "when the timeout options are not set" do
@@ -68,6 +75,13 @@ describe RubyBox::Session do
       it "does not passes them along to Net::HTTP, in order to use that library's defaults" do
         Net::HTTP.any_instance.should_not_receive(:read_timeout=).with(read_timeout)
         Net::HTTP.any_instance.should_not_receive(:open_timeout=).with(open_timeout)
+        session.request(uri, request)
+      end
+
+      it "does not pass options to Faraday" do
+        OAuth2::Client.should_receive(:new) do |_, _, opts|
+          opts[:connection_opts].should == { request: {} }
+        end
         session.request(uri, request)
       end
     end


### PR DESCRIPTION
This has been discussed before in https://github.com/attachmentsme/ruby-box/issues/60

The idea is to allow library users to configure network timeouts to suit their needs. 
